### PR TITLE
Add TLS dataset pairing and update README instructions

### DIFF
--- a/examples/tls_finetuning/README.md
+++ b/examples/tls_finetuning/README.md
@@ -1,0 +1,52 @@
+# TLS Finetuning Example
+
+This example demonstrates how to finetune `micro_sam` on whole-slide images
+(SVS) with cell annotations in GeoJSON format. It prepares instance masks from
+GeoJSON, builds a data loader using `torch_em`, and runs the training with
+`micro_sam.training.train_sam`.
+
+Files
+-----
+- `prepare_data.py`: Convert GeoJSON annotations to instance masks.
+- `dataset.py`: Defines `TLSDataset` for loading SVS images and masks.
+- `finetune_tls.py`: Script to start the finetuning and export the model.
+
+### Dataset Layout
+
+The code assumes that slides and annotations have matching base names, e.g.
+```
+XNYY-LUAD-0001.svs
+XNYY-LUAD-0001.geojson
+```
+After converting the GeoJSON files with `prepare_data.py` the folder structure
+should look like
+
+```
+examples/tls_finetuning/data/
+    images/   # contains *.svs files
+    geojson/  # original annotations
+    masks/    # generated instance masks (*.tif)
+```
+
+### Running the Example
+
+1. **Prepare the masks**
+
+   Convert all GeoJSON annotations to instance masks. Replace `PATH_TO_IMAGES`
+   and `PATH_TO_GEOJSON` with your directories containing the slides and labels
+   and choose an output folder for the masks.
+
+   ```bash
+   python prepare_data.py PATH_TO_IMAGES PATH_TO_GEOJSON data/masks
+   ```
+
+2. **Start finetuning**
+
+   Place the SVS files in `data/images` and run:
+
+   ```bash
+   python finetune_tls.py
+   ```
+
+   This will train SAM together with the instance decoder and export the
+   resulting weights to `finetuned_tls_model.pth`.

--- a/examples/tls_finetuning/dataset.py
+++ b/examples/tls_finetuning/dataset.py
@@ -1,0 +1,113 @@
+"""Dataset utilities for TLS finetuning."""
+
+import os
+import random
+from glob import glob
+from pathlib import Path
+from typing import List, Sequence, Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset, DataLoader
+from PIL import Image
+
+
+class TLSDataset(Dataset):
+    """Random patch dataset for SVS images with instance masks."""
+
+    def __init__(
+        self,
+        image_paths: Sequence[str],
+        mask_paths: Sequence[str],
+        patch_shape: Tuple[int, int] = (1024, 1024),
+        n_samples: int = 100,
+    ) -> None:
+        assert len(image_paths) == len(mask_paths), "Images and masks mismatch"
+        self.image_paths = list(image_paths)
+        self.mask_paths = list(mask_paths)
+        self.patch_shape = patch_shape
+        self.n_samples = n_samples
+
+        try:
+            import openslide  # lazy import
+        except ImportError as e:
+            raise RuntimeError(
+                "openslide-python must be installed to read SVS files"
+            ) from e
+
+        self.slides = [openslide.OpenSlide(p) for p in self.image_paths]
+        self.masks = [np.array(Image.open(p)) for p in self.mask_paths]
+        self.sizes = [slide.dimensions for slide in self.slides]
+
+    def __len__(self) -> int:
+        return self.n_samples
+
+    def _sample_location(self, width: int, height: int) -> Tuple[int, int]:
+        ph, pw = self.patch_shape
+        x0 = random.randint(0, width - pw)
+        y0 = random.randint(0, height - ph)
+        return x0, y0
+
+    def __getitem__(self, index: int):
+        slide_idx = index % len(self.slides)
+        slide = self.slides[slide_idx]
+        mask = self.masks[slide_idx]
+        width, height = self.sizes[slide_idx]
+
+        x0, y0 = self._sample_location(width, height)
+        ph, pw = self.patch_shape
+
+        patch = slide.read_region((x0, y0), 0, (pw, ph))
+        patch = np.asarray(patch)[..., :3]
+        label = mask[y0 : y0 + ph, x0 : x0 + pw]
+
+        patch = torch.from_numpy(patch.transpose(2, 0, 1)).float() / 255.0
+        label = torch.from_numpy(label.astype(np.int64))
+        return patch, label
+
+
+def get_dataloader(
+    image_dir: str,
+    mask_dir: str,
+    patch_shape: Tuple[int, int],
+    batch_size: int,
+    n_samples: int,
+    split: str,
+) -> DataLoader:
+    """Create dataloader for training or validation."""
+    assert split in {"train", "val"}
+    def pair_paths(image_dir: str, mask_dir: str) -> Tuple[List[str], List[str]]:
+        image_dir = Path(image_dir)
+        mask_dir = Path(mask_dir)
+        images: List[str] = []
+        masks: List[str] = []
+        for img_path in sorted(image_dir.glob("*.svs")):
+            base = img_path.stem
+            mask_path = mask_dir / f"{base}.tif"
+            if not mask_path.exists():
+                raise FileNotFoundError(f"Mask for {img_path.name} not found")
+            images.append(str(img_path))
+            masks.append(str(mask_path))
+        return images, masks
+
+    image_paths, mask_paths = pair_paths(image_dir, mask_dir)
+
+    # simple split based on file order
+    val_fraction = 0.1
+    n_val = max(1, int(len(image_paths) * val_fraction))
+
+    if split == "train":
+        image_paths = image_paths[:-n_val]
+        mask_paths = mask_paths[:-n_val]
+    else:
+        image_paths = image_paths[-n_val:]
+        mask_paths = mask_paths[-n_val:]
+
+    dataset = TLSDataset(
+        image_paths=image_paths,
+        mask_paths=mask_paths,
+        patch_shape=patch_shape,
+        n_samples=n_samples * batch_size,
+    )
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=True, num_workers=4)
+    return loader

--- a/examples/tls_finetuning/finetune_tls.py
+++ b/examples/tls_finetuning/finetune_tls.py
@@ -1,0 +1,64 @@
+"""Finetune SAM on TLS data."""
+
+import os
+
+import torch
+
+import micro_sam.training as sam_training
+from micro_sam.util import export_custom_sam_model
+
+from .dataset import get_dataloader
+
+
+DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
+IMAGES = os.path.join(DATA_ROOT, "images")
+MASKS = os.path.join(DATA_ROOT, "masks")
+
+
+def run_training(checkpoint_name: str, model_type: str, train_decoder: bool) -> None:
+    """Run SAM finetuning."""
+    patch_shape = (1024, 1024)
+    batch_size = 1
+
+    train_loader = get_dataloader(
+        IMAGES, MASKS, patch_shape, batch_size, n_samples=50, split="train"
+    )
+    val_loader = get_dataloader(
+        IMAGES, MASKS, patch_shape, batch_size, n_samples=4, split="val"
+    )
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    sam_training.train_sam(
+        name=checkpoint_name,
+        model_type=model_type,
+        train_loader=train_loader,
+        val_loader=val_loader,
+        patch_shape=patch_shape,
+        checkpoint=None,
+        with_segmentation_decoder=train_decoder,
+        device=device,
+    )
+
+
+def export_model(checkpoint_name: str, model_type: str) -> None:
+    export_path = os.path.join(os.path.dirname(__file__), "finetuned_tls_model.pth")
+    checkpoint_path = os.path.join("checkpoints", checkpoint_name, "best.pt")
+    export_custom_sam_model(
+        checkpoint_path=checkpoint_path,
+        model_type=model_type,
+        save_path=export_path,
+    )
+
+
+def main() -> None:
+    model_type = "vit_b"
+    checkpoint_name = "sam_tls"
+    train_decoder = True
+
+    run_training(checkpoint_name, model_type, train_decoder)
+    export_model(checkpoint_name, model_type)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tls_finetuning/prepare_data.py
+++ b/examples/tls_finetuning/prepare_data.py
@@ -1,0 +1,103 @@
+"""Utilities to convert GeoJSON annotations to instance masks."""
+
+import json
+import os
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+try:
+    from shapely.geometry import shape
+except ImportError:  # fallback if shapely is not installed
+    shape = None
+
+
+def _draw_polygon(draw: ImageDraw.ImageDraw, coords, obj_id: int) -> None:
+    """Draw a polygon into ``draw`` with ``obj_id``."""
+    xy = [(x, y) for x, y in coords]
+    draw.polygon(xy, outline=obj_id, fill=obj_id)
+
+
+def geojson_to_mask(geojson_path: str, slide_size: Tuple[int, int]) -> np.ndarray:
+    """Convert a single GeoJSON file to an instance mask.
+
+    Args:
+        geojson_path: Path to the GeoJSON annotation.
+        slide_size: Tuple ``(width, height)`` of the slide.
+
+    Returns:
+        ``H x W`` array with ``uint32`` labels.
+    """
+    with open(geojson_path, "r") as f:
+        data = json.load(f)
+
+    mask_img = Image.new("I", slide_size, 0)  # 32 bit integer mask
+    draw = ImageDraw.Draw(mask_img)
+
+    for obj_id, feature in enumerate(data.get("features", []), start=1):
+        geom = feature["geometry"]
+        if geom["type"] == "Polygon":
+            coords = geom["coordinates"][0]
+            _draw_polygon(draw, coords, obj_id)
+        elif geom["type"] == "MultiPolygon":
+            for poly in geom["coordinates"]:
+                coords = poly[0]
+                _draw_polygon(draw, coords, obj_id)
+        else:
+            if shape is not None:
+                polygon = shape(geom)
+                coords = list(polygon.exterior.coords)
+                _draw_polygon(draw, coords, obj_id)
+            else:
+                raise ValueError(f"Unsupported geometry type: {geom['type']}")
+
+    mask = np.array(mask_img, dtype=np.uint32)
+    return mask
+
+
+def convert_dataset(image_dir: str, label_dir: str, output_dir: str) -> None:
+    """Convert all GeoJSON files in ``label_dir`` to masks and save them.
+
+    The output masks will have the same base name as the GeoJSON files but with
+    ``.tif`` extension.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    image_dir = Path(image_dir)
+    label_dir = Path(label_dir)
+
+    for label_file in sorted(label_dir.glob("*.geojson")):
+        slide_name = label_file.stem
+        svs_path = image_dir / f"{slide_name}.svs"
+        if not svs_path.exists():
+            raise FileNotFoundError(f"Slide {svs_path} not found")
+
+        try:
+            import openslide
+        except ImportError as e:
+            raise RuntimeError(
+                "openslide-python must be installed to read SVS files"
+            ) from e
+
+        slide = openslide.OpenSlide(str(svs_path))
+        width, height = slide.dimensions
+        mask = geojson_to_mask(str(label_file), (width, height))
+
+        mask_path = Path(output_dir) / f"{slide_name}.tif"
+        Image.fromarray(mask).save(mask_path)
+        print(f"Saved mask {mask_path}")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Convert TLS GeoJSON to masks")
+    parser.add_argument("image_dir", help="Directory with SVS images")
+    parser.add_argument("label_dir", help="Directory with GeoJSON files")
+    parser.add_argument(
+        "output_dir", help="Directory to store the generated masks"
+    )
+
+    args = parser.parse_args()
+    convert_dataset(args.image_dir, args.label_dir, args.output_dir)


### PR DESCRIPTION
## Summary
- ensure SVS slides match masks by filename in TLS dataloader
- document dataset layout and how to run the TLS finetuning example

## Testing
- `pytest -q -o addopts=''` *(fails: ModuleNotFoundError: No module named 'numpy')*