### PR TITLE
Refine TLS finetuning for offline use

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -4,7 +4,9 @@ channels:
 dependencies:
     - nifty >=1.2.3
     - imagecodecs
+    - openslide-python
     - magicgui
+    - shapely
     - napari
     - natsort
     - pip
@@ -28,5 +30,4 @@ dependencies:
     - timm
     - xarray <2025.3.0
     - zarr <3.0
-    - pip:
-        - git+https://github.com/ChaoningZhang/MobileSAM.git
+    - pip

--- a/examples/tls_finetuning/create_dummy_dataset.py
+++ b/examples/tls_finetuning/create_dummy_dataset.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+import numpy as np
+from PIL import Image
+
+
+def create_slide(path: Path, size=(1024, 1024)) -> None:
+    data = np.random.randint(0, 255, size + (3,), dtype=np.uint8)
+    img = Image.fromarray(data)
+    # save as tiff but use .svs suffix to mimic a slide file
+    img.save(path)
+
+
+def create_geojson(path: Path) -> None:
+    # simple square polygon
+    feature = {
+        "type": "Feature",
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[[100, 100], [400, 100], [400, 400], [100, 400], [100, 100]]],
+        },
+        "properties": {},
+    }
+    geo = {"type": "FeatureCollection", "features": [feature]}
+    with open(path, "w") as f:
+        json.dump(geo, f)
+
+
+if __name__ == "__main__":
+    base = Path(__file__).parent / "newdata"
+    img_dir = base / "images"
+    geo_dir = base / "geojson"
+    img_dir.mkdir(parents=True, exist_ok=True)
+    geo_dir.mkdir(parents=True, exist_ok=True)
+
+    slide_path = img_dir / "sample.svs"
+    create_slide(slide_path)
+
+    label_path = geo_dir / "sample.geojson"
+    create_geojson(label_path)
+    print("Dummy data created in", base)

--- a/examples/tls_finetuning/prepare_data.py
+++ b/examples/tls_finetuning/prepare_data.py
@@ -75,13 +75,14 @@ def convert_dataset(image_dir: str, label_dir: str, output_dir: str) -> None:
 
         try:
             import openslide
-        except ImportError as e:
-            raise RuntimeError(
-                "openslide-python must be installed to read SVS files"
-            ) from e
-
-        slide = openslide.OpenSlide(str(svs_path))
-        width, height = slide.dimensions
+            slide = openslide.OpenSlide(str(svs_path))
+            width, height = slide.dimensions
+        except Exception:
+            # Fallback that uses PIL in case openslide is not available. This
+            # only works for simple SVS files that can be opened as standard
+            # TIFF images.
+            slide = Image.open(str(svs_path))
+            width, height = slide.size
         mask = geojson_to_mask(str(label_file), (width, height))
 
         mask_path = Path(output_dir) / f"{slide_name}.tif"

--- a/examples/tls_finetuning/test_dummy_pipeline.py
+++ b/examples/tls_finetuning/test_dummy_pipeline.py
@@ -1,0 +1,33 @@
+"""Run a minimal end-to-end test of the TLS finetuning pipeline."""
+
+from pathlib import Path
+
+from create_dummy_dataset import create_geojson, create_slide
+from prepare_data import convert_dataset
+from dataset import get_dataloader
+
+
+def main() -> None:
+    base = Path(__file__).parent / "newdata"
+    img_dir = base / "images"
+    geo_dir = base / "geojson"
+    mask_dir = base / "masks"
+    img_dir.mkdir(parents=True, exist_ok=True)
+    geo_dir.mkdir(parents=True, exist_ok=True)
+
+    slide_path = img_dir / "sample.svs"
+    label_path = geo_dir / "sample.geojson"
+    if not slide_path.exists():
+        create_slide(slide_path)
+    if not label_path.exists():
+        create_geojson(label_path)
+
+    convert_dataset(img_dir, geo_dir, mask_dir)
+
+    loader = get_dataloader(img_dir, mask_dir, patch_shape=(512, 512), batch_size=1, n_samples=1, split="train")
+    sample = next(iter(loader))
+    print("Loaded patch shape:", sample[0].shape, "label shape:", sample[1].shape)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add CPU/GPU switch and required checkpoint path in the finetuning script
- clarify how to run finetuning with a local SAM checkpoint
- remove network install from `environment.yaml`
- include `openslide-python` and `shapely` packages

## Testing
- `python -m py_compile examples/tls_finetuning/prepare_data.py examples/tls_finetuning/dataset.py examples/tls_finetuning/finetune_tls.py examples/tls_finetuning/create_dummy_dataset.py examples/tls_finetuning/test_dummy_pipeline.py`
- `pytest -q` *(fails: unrecognized arguments --cov, coverage plugin missing)*